### PR TITLE
modifying vanilla price input and description. setting up american op…

### DIFF
--- a/tf_quant_finance/black_scholes/BUILD
+++ b/tf_quant_finance/black_scholes/BUILD
@@ -13,6 +13,7 @@ py_library(
         ":implied_vol_lib",
         ":implied_vol_newton_root",
         ":vanilla_prices",
+        "//tf_quant_finance/black_scholes/approximations",
         # numpy dep,
         # tensorflow dep,
     ],
@@ -126,3 +127,4 @@ py_test(
         # tensorflow dep,
     ],
 )
+

--- a/tf_quant_finance/black_scholes/__init__.py
+++ b/tf_quant_finance/black_scholes/__init__.py
@@ -15,6 +15,7 @@
 """TensorFlow Quantitative Finance volatility surfaces and vanilla options."""
 
 from tf_quant_finance.black_scholes import vanilla_prices
+from tf_quant_finance.black_scholes import approximations
 from tf_quant_finance.black_scholes.implied_vol_approximation import implied_vol as implied_vol_approx
 from tf_quant_finance.black_scholes.implied_vol_lib import implied_vol
 from tf_quant_finance.black_scholes.implied_vol_lib import ImpliedVolMethod
@@ -26,6 +27,7 @@ binary_price = vanilla_prices.binary_price
 option_price = vanilla_prices.option_price
 
 _allowed_symbols = [
+    'approximations',
     'binary_price',
     'implied_vol',
     'implied_vol_approx',

--- a/tf_quant_finance/black_scholes/approximations/BUILD
+++ b/tf_quant_finance/black_scholes/approximations/BUILD
@@ -1,0 +1,34 @@
+
+package(default_visibility = ["//tf_quant_finance:__subpackages__"])
+
+py_library(
+    name = "approximations",
+    srcs = ["__init__.py"],
+    srcs_version = "PY3",
+    deps = [
+        ":american_option",
+        # numpy dep,
+        # tensorflow dep,
+    ],
+)
+
+py_library(
+    name = "american_option",
+    srcs = ["american_option.py"],
+    srcs_version = "PY3",
+    deps = [
+        # tensorflow dep,
+        # numpy dep,
+  ],
+)
+
+py_test(
+    name = "american_option_test",
+    srcs = ["american_option_test.py"],
+    python_version = "PY3",
+    deps = [
+        "//tf_quant_finance",
+        # numpy dep,
+        # tensorflow dep,
+    ],
+)

--- a/tf_quant_finance/black_scholes/approximations/__init__.py
+++ b/tf_quant_finance/black_scholes/approximations/__init__.py
@@ -1,0 +1,30 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as: python2, python3
+"""Approximations to the black scholes formula."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tf_quant_finance.black_scholes.approximations.american_option import adesi_whaley
+from tensorflow.python.util.all_util import remove_undocumented  # pylint: disable=g-direct-tensorflow-import
+
+_allowed_symbols = [
+    'adesi_whaley',
+    'american_option',
+]
+
+remove_undocumented(__name__, _allowed_symbols)

--- a/tf_quant_finance/black_scholes/approximations/american_option.py
+++ b/tf_quant_finance/black_scholes/approximations/american_option.py
@@ -1,0 +1,423 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Baron-Adesi Whaley approximation of the Black Scholes equation to calculate
+ the price of a batch of American options."""
+
+import numpy as np
+import tensorflow.compat.v2 as tf
+import tf_quant_finance as tff
+import tf_quant_finance.black_scholes.implied_vol_newton_root as implied_vol_newton
+
+
+def adesi_whaley(volatilities,
+                 strikes,
+                 expiries,
+                 risk_free_rates,
+                 cost_of_carries,
+                 spots=None,
+                 forwards=None,
+                 is_call_options=None,
+                 dtype=None,
+                 name="american_price"):
+  """Computes the price for a batch of call or put options, using an approximate
+  pricing formula, the Baron-Adesi Whaley approximation
+
+  #### Example
+
+  ```python
+  spots = np.array([80.0, 90.0, 100.0, 110.0, 120.0])
+  strikes = np.array([100.0, 100.0, 100.0, 100.0, 100.0])
+  volatilities = np.array([0.2, 0.2, 0.2, 0.2, 0.2])
+  expiries = 0.25
+  cost_of_carries = -0.04
+  risk_free_rates = 0.08
+  computed_prices = adesi_whaley(
+      volatilities,
+      strikes,
+      expiries,
+      risk_free_rates,
+      cost_of_carries,
+      spots=spots,
+      dtype=tf.float64)
+  # Expected print output of computed prices:
+  # [0.03, 0.59, 3.52, 10.31, 20.0]
+  ```
+  The naming convention will align variables with the variables named in
+  reference [1], but made lower case, and differentiating between put and
+  call option values with the suffix _put and _call.
+
+  ## References:
+  [1] Baron-Adesi, Whaley, Efficient Analytic Approximation of American Option
+    Values, The Journal of Finance, Vol XLII, No. 2, June 1987
+    https://deriscope.com/docs/Barone_Adesi_Whaley_1987.pdf
+
+  Args:
+  volatilities: Real `Tensor` of any shape and dtype. The volatilities to
+    expiry of the options to price.
+  strikes: A real `Tensor` of the same dtype and compatible shape as
+    `volatilities`. The strikes of the options to be priced.
+  expiries: A real `Tensor` of same dtype and compatible shape as
+    `volatilities`. The expiry of each option. The units should be such that
+    `expiry * volatility**2` is dimensionless.
+  spots: A real `Tensor` of any shape that broadcasts to the shape of the
+    `volatilities`. The current spot price of the underlying. Either this
+    argument or the `forwards` (but not both) must be supplied.
+  forwards: A real `Tensor` of any shape that broadcasts to the shape of
+    `volatilities`. The forwards to maturity. Either this argument or the
+    `spots` must be supplied but both must not be supplied.
+  risk_free_rates: An real `Tensor` of same dtype and compatible shape as
+    `volatilities`. Discount factors are calculated using it: e^(-rT), where r
+    is the risk free rate.
+  cost_of_carries: An real `Tensor` of same dtype and compatible shape as
+    `volatilities`. If `spots` is supplied, used to calculate forwards from
+    spots: F = e^(bT) * S.
+  is_call_options: A boolean `Tensor` of a shape compatible with
+    `volatilities`. Indicates whether the option is a call (if True) or a put
+    (if False). If not supplied, call options are assumed.
+  dtype: Optional `tf.DType`. If supplied, the dtype to be used for conversion
+    of any supplied non-`Tensor` arguments to `Tensor`.
+    Default value: None which maps to the default dtype inferred by TensorFlow
+      (float32).
+  name: str. The name for the ops created by this function.
+    Default value: None which is mapped to the default name `option_price`.
+
+  Returns:
+    option_prices: A `Tensor` of the same shape as `forwards`. The Black
+    Scholes price of the options.
+
+  Raises:
+    ValueError: If both `forwards` and `spots` are supplied or if neither is
+      supplied.
+  """
+  if (spots is None) == (forwards is None):
+    raise ValueError('Either spots or forwards must be supplied but not both.')
+
+  # if b>=r, return European only, if b<r, return American only, if mixed, split
+  return tf.case(
+    [(tf.reduce_all(cost_of_carries >= risk_free_rates),
+      lambda: tff.black_scholes.option_price(
+        volatilities, strikes, expiries, spots=spots, forwards=forwards,
+        risk_free_rates=risk_free_rates, cost_of_carries=cost_of_carries,
+        is_call_options=is_call_options, dtype=dtype, name=name)),
+     (tf.reduce_all(cost_of_carries < risk_free_rates),
+        lambda: _option_price(*_convert_to_tensors(
+          volatilities, strikes, expiries, risk_free_rates, cost_of_carries,
+          spots=spots, forwards=forwards, is_call_options=is_call_options,
+          dtype=dtype, name=name)))],
+    default=lambda: _split_out(
+          volatilities, strikes, expiries, spots=spots, forwards=forwards,
+          risk_free_rates=risk_free_rates, cost_of_carries=cost_of_carries,
+          is_call_options=is_call_options, dtype=dtype, name=name),
+    exclusive=True)
+
+
+def _split_out(volatilities,
+               strikes,
+               expiries,
+               risk_free_rates,
+               cost_of_carries,
+               spots=None,
+               forwards=None,
+               is_call_options=None,
+               dtype=None,
+               name="american_price"):
+  """
+  Splits prices out to European and American batches, then combines the result.
+  """
+
+  if forwards is not None:
+    t = tf.broadcast_to(tf.convert_to_tensor(
+      expiries, dtype=dtype), forwards.shape, name="expiries")
+    s = tf.convert_to_tensor(
+      forwards * tf.exp(- cost_of_carries * t),
+      dtype=dtype,
+      name="spots")
+  else:
+    t = tf.broadcast_to(tf.convert_to_tensor(
+      expiries, dtype=dtype), spots.shape, name="expiries")
+    s = tf.convert_to_tensor(spots, dtype=dtype, name="spots")
+
+  b_less_r = risk_free_rates > cost_of_carries
+  b_more_eq_r = risk_free_rates <= cost_of_carries
+  am_indices = tf.where(b_less_r)
+  eu_indices = tf.where(b_more_eq_r)
+  shape = tf.shape(s, out_type=am_indices.dtype)
+
+  strikes = tf.broadcast_to(tf.convert_to_tensor(
+    strikes, dtype=dtype), shape, name="strikes")
+  volatilities = tf.broadcast_to(tf.convert_to_tensor(
+    volatilities, dtype=dtype), shape, name="volatilities")
+  cost_of_carries = tf.broadcast_to(tf.convert_to_tensor(
+    cost_of_carries, dtype=dtype), shape, name="cost_of_carries")
+  risk_free_rates = tf.broadcast_to(tf.convert_to_tensor(
+    risk_free_rates, dtype=dtype), shape, name="risk_free_rates")
+
+  if is_call_options is not None:
+    is_call_options = tf.broadcast_to(tf.convert_to_tensor(
+      is_call_options), s.shape, name="risk_free_rates")
+    is_call_eu = tf.gather_nd(is_call_options, eu_indices)
+    is_call_am = tf.gather_nd(is_call_options, am_indices)
+  else:
+    is_call_eu, is_call_am = None, None
+
+  x_eu = tf.gather_nd(strikes, eu_indices)
+  sigma_eu = tf.gather_nd(volatilities, eu_indices)
+  s_eu = tf.gather_nd(s, eu_indices)
+  t_eu = tf.gather_nd(t, eu_indices)
+  r_eu = tf.gather_nd(risk_free_rates, eu_indices)
+  b_eu = tf.gather_nd(cost_of_carries, eu_indices)
+
+  x_am = tf.gather_nd(strikes, am_indices)
+  sigma_am = tf.gather_nd(volatilities, am_indices)
+  s_am = tf.gather_nd(s, am_indices)
+  t_am = tf.gather_nd(t, am_indices)
+  r_am = tf.gather_nd(risk_free_rates, am_indices)
+  b_am = tf.gather_nd(cost_of_carries, am_indices)
+
+  eu_prices = tff.black_scholes.option_price(
+    sigma_eu, x_eu, t_eu, spots=s_eu, risk_free_rates=r_eu,
+    cost_of_carries=b_eu, is_call_options=is_call_eu, dtype=dtype, name=name)
+
+  eu_prices_or_zero = tf.scatter_nd(eu_indices, eu_prices, shape)
+
+  am_prices = _option_price(
+      sigma_am, x_am, t_am, spots=s_am, risk_free_rates=r_am,
+      cost_of_carries=b_am, is_call_options=is_call_am, dtype=dtype, name=name)
+
+  return tf.where(b_more_eq_r, eu_prices_or_zero, am_prices)
+
+
+def _convert_to_tensors(volatilities,
+                        strikes,
+                        expiries,
+                        risk_free_rates,
+                        cost_of_carries,
+                        spots=None,
+                        forwards=None,
+                        is_call_options=None,
+                        dtype=None,
+                        name=None):
+  """
+  Converts to tensors the np.array inputs.
+  """
+  if forwards is not None:
+    expiries = tf.broadcast_to(tf.convert_to_tensor(
+      expiries, dtype=dtype), forwards.shape, name="expiries")
+    spots = tf.convert_to_tensor(
+      forwards * tf.exp(- cost_of_carries * expiries),
+      dtype=dtype,
+      name="spots")
+  else:
+    expiries = tf.broadcast_to(tf.convert_to_tensor(
+      expiries, dtype=dtype), spots.shape, name="expiries")
+    spots = tf.convert_to_tensor(spots, dtype=dtype, name="spots")
+
+  strikes = tf.broadcast_to(tf.convert_to_tensor(
+    strikes, dtype=dtype), spots.shape, name="strikes")
+  volatilities = tf.broadcast_to(tf.convert_to_tensor(
+    volatilities, dtype=dtype), spots.shape, name="volatilities")
+  cost_of_carries = tf.broadcast_to(tf.convert_to_tensor(
+    cost_of_carries, dtype=dtype), spots.shape, name="cost_of_carries")
+  risk_free_rates = tf.broadcast_to(tf.convert_to_tensor(
+    risk_free_rates, dtype=dtype), spots.shape, name="risk_free_rates")
+  return (
+    volatilities, strikes, expiries, risk_free_rates, cost_of_carries, spots,
+    is_call_options, dtype, name)
+  
+
+def _option_price(volatilities,
+                  strikes,
+                  expiries,
+                  risk_free_rates,
+                  cost_of_carries,
+                  spots=None,
+                  is_call_options=None,
+                  dtype=None,
+                  name=None):
+  """Computes the price for a batch of call or put options, using an approximate
+    pricing formula, the Baron-Adesi Whaley approximation
+
+    The naming convention will align variables with the variables named in
+    reference [1], but made lower case, and differentiating between put and
+    call option values with the suffix _put and _call.
+
+    ## References:
+    [1] Baron-Adesi, Whaley, Efficient Analytic Approximation of American Option
+      Values, The Journal of Finance, Vol XLII, No. 2, June 1987;
+      https://deriscope.com/docs/Barone_Adesi_Whaley_1987.pdf
+
+    Returns:
+      option_prices: A `Tensor` of the same shape as `forwards` or `spots`.
+      The Baron-Adesi-Whaley approximation of the price of the american options.
+    """
+
+  with tf.name_scope(name):
+    where_call = tf.broadcast_to(
+      tf.constant(True), spots.shape) if is_call_options is None else is_call_options
+    call_indices = tf.where(where_call)
+    put_indices = tf.where(tf.logical_not(where_call))
+
+    if is_call_options is None:
+      sigma_call = volatilities
+      x_call = strikes
+      s_call = spots
+      t_call = expiries
+      r_call = risk_free_rates
+      b_call = cost_of_carries
+
+    else:
+      x_call = tf.gather_nd(strikes, call_indices)
+      sigma_call = tf.gather_nd(volatilities, call_indices)
+      s_call = tf.gather_nd(spots, call_indices)
+      t_call = tf.gather_nd(expiries, call_indices)
+      r_call = tf.gather_nd(risk_free_rates, call_indices)
+      b_call = tf.gather_nd(cost_of_carries, call_indices)
+
+    q2, a2, s_crit_call = _option_price_put_or_call(
+      sigma_call, x_call, t_call, r_call, b_call, s_call, True, dtype)
+
+    # Calculate eu_call_prices only for spot prices that are less than s_crit
+    is_less_than_s_crit = s_call < s_crit_call
+    indices = tf.where(is_less_than_s_crit)
+    shape = tf.shape(s_call, out_type=indices.dtype)
+    s_crit_s_call = tf.gather_nd(s_call, indices)
+    s_crit_t_call = tf.gather_nd(t_call, indices)
+    s_crit_sigma_call = tf.gather_nd(sigma_call, indices)
+    s_crit_x_call = tf.gather_nd(x_call, indices)
+    s_crit_r_call = tf.gather_nd(r_call, indices)
+    s_crit_b_call = tf.gather_nd(b_call, indices)
+
+    eu_call_prices = tff.black_scholes.option_price(
+      volatilities=s_crit_sigma_call, strikes=s_crit_x_call,
+      expiries=s_crit_t_call, spots=s_crit_s_call,
+      risk_free_rates=s_crit_r_call, cost_of_carries=s_crit_b_call,
+      dtype=dtype, name=name)
+    eu_call_prices_or_zero = tf.scatter_nd(indices, eu_call_prices, shape)
+
+    american_call_prices = tf.where(
+      is_less_than_s_crit,
+      eu_call_prices_or_zero + a2 * (s_call / s_crit_call) ** q2,
+      s_call - x_call)
+
+    if is_call_options is None:
+      return american_call_prices
+
+    # Put option
+    x_put = tf.gather_nd(strikes, put_indices)
+    sigma_put = tf.gather_nd(volatilities, put_indices)
+    s_put = tf.gather_nd(spots, put_indices)
+    t_put = tf.gather_nd(expiries, put_indices)
+    r_put = tf.gather_nd(risk_free_rates, put_indices)
+    b_put = tf.gather_nd(cost_of_carries, put_indices)
+
+    q1, a1, s_crit_put = _option_price_put_or_call(
+      sigma_put, x_put, t_put, r_put, b_put, s_put, False, dtype)
+
+    # Calculate eu_put_prices only for spot prices larger than s_crit
+    is_more_than_s_crit = s_put > s_crit_put
+    indices = tf.where(is_more_than_s_crit)
+    shape = tf.shape(s_put, out_type=indices.dtype)
+    s_crit_s_put = tf.gather_nd(s_put, indices)
+    s_crit_t_put = tf.gather_nd(t_put, indices)
+    s_crit_sigma_put = tf.gather_nd(sigma_put, indices)
+    s_crit_x_put = tf.gather_nd(x_put, indices)
+    s_crit_r_put = tf.gather_nd(r_put, indices)
+    s_crit_b_put = tf.gather_nd(b_put, indices)
+
+    eu_put_prices = tff.black_scholes.option_price(
+      volatilities=s_crit_sigma_put, strikes=s_crit_x_put,
+      expiries=s_crit_t_put, spots=s_crit_s_put,
+      risk_free_rates=s_crit_r_put, cost_of_carries=s_crit_b_put,
+      is_call_options=tf.constant(False), dtype=dtype, name=name)
+    eu_put_prices_or_zero = tf.scatter_nd(indices, eu_put_prices, shape)
+
+    american_put_prices = tf.where(
+      is_more_than_s_crit,
+      eu_put_prices_or_zero + a1 * (s_put / s_crit_put) ** q1,
+      x_put - s_put)
+
+    shape = tf.shape(spots, out_type=call_indices.dtype)
+
+    call_or_zero = tf.scatter_nd(call_indices, american_call_prices, shape)
+    put_or_zero = tf.scatter_nd(put_indices, american_put_prices, shape)
+    return tf.where(is_call_options, call_or_zero, put_or_zero)
+
+
+def _option_price_put_or_call(sigma, x, t, r, b, s, call, dtype):
+  """ Calculates q, a for the american option price formula.
+  Also calculates the critical spot price above and below which the american
+  option price formula behaves differently.
+
+  :param sigma:
+  :param x:
+  :param t:
+  :param r:
+  :param b:
+  :param s:
+  :param call:
+  :param dtype:
+  :return:
+  """
+  is_call_options = None if call else tf.constant(False)
+  sign = 1 if call else -1
+
+  M = 2 * r / sigma ** 2
+  N = 2 * b / sigma ** 2
+  K = 1 - tf.exp(- r * t)
+  q_ = _calc_q(N, M, K, call)
+
+  value = lambda s_crit: tff.black_scholes.option_price(
+    volatilities=sigma, strikes=x, expiries=t, spots=s_crit, risk_free_rates=r,
+    cost_of_carries=b, is_call_options=is_call_options, dtype=dtype) + sign * (
+      1 - tf.exp((b - r) * t) * _ncdf(sign * _calc_d1(
+    s_crit, x, sigma, b, t))) * s_crit / q_ - sign * (s_crit - x)
+
+  value_and_gradient = lambda price: tff.math.value_and_gradient(value, price)
+
+  # Calculate seed value for critical spot price
+  q_inf = _calc_q(N, M, call=call)
+  s_inf = x / (1 - 1 / q_inf)
+  h = -(sign * b * t + 2 * sigma * tf.sqrt(t)) * sign * (x / (s_inf - x))
+  if call:
+    s_seed = x + (s_inf - x) * (1 - tf.exp(h))
+  else:
+    s_seed = s_inf + (x - s_inf) * tf.exp(h)
+
+  s_crit, _, _ = implied_vol_newton.newton_root_finder(
+    value_and_gradient, s_seed, dtype=dtype)
+
+  a_ = (sign * s_crit / q_) * (1 - tf.exp((b - r) * t) * _ncdf(
+    sign * _calc_d1(s_crit, x, sigma, b, t)))
+
+  return q_, a_, s_crit
+
+
+def _calc_d1(s, x, sigma, b, t):
+  return (tf.math.log(s / x) + (b + sigma ** 2 / 2) * t) / (
+      sigma * tf.math.sqrt(t))
+
+def _calc_q(N, M, K=1, call=True):
+  sign = 1 if call else -1
+  return ((1 - N) + sign * tf.sqrt((N - 1) ** 2 + 4 * M / K)) / 2
+
+
+def _ncdf(x):
+  return (tf.math.erf(x / _SQRT_2) + 1) / 2
+
+
+def _npdf(x):
+  return tf.exp(-0.5 * x ** 2) / tf.math.sqrt(2 * np.pi)
+
+
+_SQRT_2 = np.sqrt(2., dtype=np.float64)

--- a/tf_quant_finance/black_scholes/approximations/american_option_test.py
+++ b/tf_quant_finance/black_scholes/approximations/american_option_test.py
@@ -1,0 +1,210 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as: python2, python3
+"""Tests for vanilla_price."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from absl.testing import parameterized
+
+import numpy as np
+import tensorflow.compat.v2 as tf
+
+import tf_quant_finance as tff
+from tensorflow.python.framework import test_util  # pylint: disable=g-direct-tensorflow-import
+
+
+print(dir(tff))
+
+@test_util.run_all_in_graph_and_eager_modes
+class AmericanPrice(parameterized.TestCase, tf.test.TestCase):
+  """Tests for methods for the american pricing module."""
+
+  @parameterized.parameters(
+    (0.08, 0.2, 0.25,
+     [0.03, 0.59, 3.52, 10.31, 20.0, 20.42, 11.25, 4.40, 1.12, 0.18],
+     [0.031208, 0.581123, 3.506973, 10.305076, 20.0, 20.418007, 11.242258,
+      4.377594, 1.102947, 0.179055]),
+    (0.12, 0.2, 0.25,
+     [0.03, 0.59, 3.51, 10.29, 20.0, 20.25, 11.15, 4.35, 1.11, 0.18],
+     [0.031361, 0.578414, 3.488747, 10.279456, 20.0, 20.247196, 11.137532,
+      4.335883, 1.092516, 0.177452]),
+    (0.08, 0.4, 0.25,
+     [1.07, 3.28, 7.41, 13.50, 21.23, 21.46, 13.93, 8.27, 4.52, 2.30],
+     [1.062566, 3.276749, 7.401451, 13.493443, 21.227011, 21.458952, 13.919689,
+      8.264548, 4.513709, 2.289232]),
+    (0.08, 0.2, 0.5,
+     [0.23, 1.39, 4.72, 10.96, 20.0, 20.98, 12.64, 6.37, 2.65, 0.92],
+     [0.219648, 1.357535, 4.677300, 10.920374, 20.0, 20.972910, 12.613128,
+      6.320176, 2.599509, 0.885091]),
+  )
+  def test_option_prices(self,
+                         risk_free_rates,
+                         volatilities,
+                         expiries,
+                         expected_prices,
+                         fake_expected_prices):
+    """Tests that the prices are correct."""
+    spots = np.array([80.0, 90.0, 100.0, 110.0, 120.0] * 2)
+    strikes = np.array([100.0] * 10)
+    is_call_options = np.array([True] * 5 + [False] * 5)
+    cost_of_carries = -0.04
+    computed_prices = self.evaluate(
+        tff.black_scholes.approximations.american_option.adesi_whaley(
+          volatilities,
+          strikes,
+          expiries,
+          risk_free_rates,
+          cost_of_carries,
+          is_call_options=is_call_options,
+          spots=spots,
+          dtype=tf.float32))
+    fake_expected_prices = np.array(fake_expected_prices)
+    expected_prices = np.array(expected_prices)
+    self.assertArrayNear(fake_expected_prices, computed_prices, 1e-3)
+
+  @parameterized.parameters(
+    (0.08, 0.2, 0.25,
+     [0.05, 0.85, 4.44, 11.66, 20.90, 20.00, 10.18, 3.54, 0.80, 0.12],
+     [0.050095, 0.836672, 4.421259, 11.651242, 20.895369, 20.0, 10.176201,
+      3.526063, 0.787715, 0.115339]),
+    (0.12, 0.2, 0.25,
+     [0.05, 0.84, 4.40, 11.55, 20.69, 20.00, 10.16, 3.53, 0.79, 0.12],
+     [0.049612, 0.828424, 4.377595, 11.536527, 20.691483, 20.000000, 10.154543,
+      3.507460, 0.783841, 0.115270]),
+    (0.08, 0.4, 0.25,
+     [1.29, 3.82, 8.35, 14.80, 22.72, 20.53, 12.93, 7.46, 3.96, 1.95],
+     [1.284287, 3.814887, 8.340343, 14.788590, 22.709639, 20.523909, 12.918881,
+      7.446249, 3.949303, 1.947205]),
+    (0.08, 0.2, 0.5,
+     [0.41, 2.18, 6.50, 13.42, 22.06, 20.00, 10.71, 4.77, 1.76, 0.55],
+     [0.394618, 2.134961, 6.442985, 13.386993, 22.041672, 20.000000, 10.675407,
+      4.723947, 1.724304, 0.527576]),
+  )
+  def test_option_prices_pos_b(self,
+                         risk_free_rates,
+                         volatilities,
+                         expiries,
+                         expected_prices,
+                         fake_expected_prices):
+    """Tests that the prices are correct."""
+    spots = np.array([80.0, 90.0, 100.0, 110.0, 120.0] * 2)
+    strikes = np.array([100.0] * 10)
+    is_call_options = [True] * 5 + [False] * 5
+    cost_of_carries = 0.04
+    computed_prices = self.evaluate(
+      tff.black_scholes.approximations.american_option.adesi_whaley(
+        volatilities,
+        strikes,
+        expiries,
+        risk_free_rates,
+        cost_of_carries,
+        spots=spots,
+        is_call_options=is_call_options,
+        dtype=tf.float32))
+
+    fake_expected_prices = np.array(fake_expected_prices)
+    expected_prices = np.array(expected_prices)
+    self.assertArrayNear(fake_expected_prices, computed_prices, 1e-3)
+
+  @parameterized.parameters(
+    (0.08, 0.2, 0.25,
+     [0.04, 0.70, 3.93, 10.81, 20.02, 20.00, 10.58, 3.93, 0.94, 0.15],
+     [0.037441, 0.686889, 3.889322, 10.724886, 19.744852, 20.796013, 10.980298,
+      3.993509, 0.948498, 0.147939]),
+    (0.12, 0.2, 0.25,
+     [0.04, 0.70, 3.90, 10.75, 20.0, 20.00, 10.53, 3.90, 0.93, 0.15],
+     [0.037082, 0.680122, 3.850909, 10.619231, 19.551895, 20.796013, 10.963469,
+      3.972912, 0.943664, 0.147720]),
+    (0.08, 0.4, 0.25,
+     [1.17, 3.53, 7.84, 14.08, 21.86, 20.93, 13.93, 7.84, 4.23, 2.12],
+     [1.157728, 3.510153, 7.798741, 14.001305, 21.704327, 21.215557, 13.514194,
+      7.896326, 4.249130, 2.126074]),
+    (0.08, 0.2, 0.5,
+     [0.30, 1.72, 5.48, 11.90, 20.34, 20.04, 11.48, 5.48, 2.15, 0.70],
+     [0.28091, 1.661523, 5.362541, 11.690692, 19.886261, 21.584106, 12.109485,
+      5.636985, 2.182215, 0.709079]),
+  )
+  def test_option_prices_futures_zero_b(self,
+                                        risk_free_rates,
+                                        volatilities,
+                                        expiries,
+                                        expected_prices,
+                                        fake_expected_prices):
+    """Tests that the prices are correct."""
+    forwards = np.array([80.0, 90.0, 100.0, 110.0, 120.0] * 2)
+    strikes = np.array([100.0] * 10)
+    is_call_options = [True] * 5 + [False] * 5
+    cost_of_carries = 0.04
+    computed_prices = self.evaluate(
+      tff.black_scholes.approximations.american_option.adesi_whaley(
+        volatilities,
+        strikes,
+        expiries,
+        risk_free_rates,
+        cost_of_carries,
+        forwards=forwards,
+        is_call_options=is_call_options,
+        dtype=tf.float32))
+
+    fake_expected_prices = np.array(fake_expected_prices)
+    expected_prices = np.array(expected_prices)
+    self.assertArrayNear(fake_expected_prices, computed_prices, 1e-3)
+
+  @parameterized.parameters(
+    (0.08, 0.2, 0.25,
+     [20.0, 10.01, 3.22, 0.68, 0.10],
+     [18.077206, 8.987599, 2.962302, 0.604106, 0.077939]),
+    (0.12, 0.2, 0.25,
+     [20.0, 10.0, 2.93, 0.58, 0.08],
+     [17.098728, 8.118369, 2.470848, 0.454215, 0.052205]),
+    (0.08, 0.4, 0.25,
+     [20.25, 12.51, 7.10, 3.71, 1.81],
+     [19.424828, 12.132558, 6.897156, 3.595204, 1.737887]),
+    (0.08, 0.2, 0.5,
+     [20.0, 10.23, 4.19, 1.45, 0.42],
+     [16.541376, 8.632272, 3.588241, 1.192073, 0.324620]),
+  )
+  def test_option_prices_b_equal_r(self,
+                                   risk_free_rates,
+                                   volatilities,
+                                   expiries,
+                                   expected_prices,
+                                   fake_expected_prices):
+    """Tests that the prices are correct."""
+    spots = np.array([80.0, 90.0, 100.0, 110.0, 120.0])
+    strikes = np.array([100.0, 100.0, 100.0, 100.0, 100.0])
+    cost_of_carries = risk_free_rates
+    is_call_options = False
+    computed_prices = self.evaluate(
+        tff.black_scholes.approximations.american_option.adesi_whaley(
+          volatilities,
+          strikes,
+          expiries,
+          risk_free_rates,
+          cost_of_carries,
+          spots=spots,
+          is_call_options=is_call_options,
+          dtype=tf.float32))
+
+    fake_expected_prices = np.array(fake_expected_prices)
+    expected_prices = np.array(expected_prices)
+
+    self.assertArrayNear(fake_expected_prices, computed_prices, 1e-3)
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tf_quant_finance/black_scholes/vanilla_prices_test.py
+++ b/tf_quant_finance/black_scholes/vanilla_prices_test.py
@@ -134,6 +134,34 @@ class VanillaPrice(tf.test.TestCase):
             forwards=forwards))
     self.assertArrayNear(base_prices, scaled_prices, 1e-10)
 
+  def test_option_prices_detailed_discount(self):
+    """Tests that the prices are when giving risk_free_rates and
+    cost_of_carries."""
+    spots = np.array([80.0, 90.0, 100.0, 110.0, 120.0] * 2)
+    strikes = np.array([100.0] * 10)
+    risk_free_rates = 0.08
+    volatilities = 0.2
+    expiries = 0.25
+
+    is_call_options = np.array([True] * 5 + [False] * 5)
+    cost_of_carries = -0.04
+    computed_prices = self.evaluate(
+      tff.black_scholes.option_price(
+        volatilities,
+        strikes,
+        expiries,
+        spots=spots,
+        risk_free_rates=risk_free_rates,
+        cost_of_carries=cost_of_carries,
+        is_call_options=is_call_options,
+        dtype=tf.float32))
+    fake_expected_prices = np.array([0.028111, 0.561231, 3.401953, 9.831990,
+                                     18.612633, 20.412336, 11.241001, 4.377268,
+                                     1.102851, 0.18])
+    expected_prices = np.array([0.03, 0.57, 3.42, 9.85, 18.62, 20.41, 11.25,
+                                4.40, 1.12, 0.18])
+    self.assertArrayNear(fake_expected_prices, computed_prices, 1e-3)
+
   def test_binary_prices(self):
     """Tests that the BS binary option prices are correct."""
     forwards = np.array([1.0, 2.0, 3.0, 4.0, 5.0])


### PR DESCRIPTION
…tion input and description

editing vanilla prices to take in cost_of_carries and riskless_rate while keeping compatibility with version that takes in discount_factors. adding reference to american_options

adding skeleton for american pricing

call option written down

starting to write down put

small progress with put option

progress with put, refactoring to make slightly nicer

further progress on calculating s** crit for put

first attempt at tests - imports not working

importing option price from black scholes directly

renaming a few modeuls

adding numpy dep;

responding to PR comments

test now failing on assertion error

adding more tests and correcting a typo

correct equation

all tests passing with outputs. will now look for bugs;

almost done